### PR TITLE
chore: modified launch.json for windows debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,19 +5,13 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "lldb",
+            "type": "cppvsdbg",
             "request": "launch",
-            "name": "Debug",
-            "program": "${workspaceFolder}/the_book/projects/hello_world/main.exe",
+            "name": "(Windows) Debug",
+            "program": "${workspaceFolder}/the_book/projects/hello_cargo/target/debug/hello_cargo_test.exe",
             "args": [],
+            "stopAtEntry": false,
             "cwd": "${workspaceFolder}"
-        },
-        {
-            "name": "Attach to a named executable",
-            "type": "lldb",
-            "request": "attach",
-            "program": "${workspaceRoot}/the_book/projects/hello_world/main.exe",
         }
-    
     ]
 }


### PR DESCRIPTION
The debugger seems to only work in the context of crates. Setup the launch.json to point toward the hello_cargo_test.exe which is built during the cargo build of the hello_cargo_test package.

In order for this to work, C/C++ tools need to be added to the vscode extensions.